### PR TITLE
fix pad CRC16: must return 4 characters

### DIFF
--- a/includes/services/class-crc16.php
+++ b/includes/services/class-crc16.php
@@ -47,6 +47,6 @@ class WP_ICPFW_CRC16
                 }
             }
         }
-        return strtoupper( dechex( $response ) );
+        return strtoupper( str_pad( dechex( $response ), 4, '0', STR_PAD_LEFT) );
     }
 }


### PR DESCRIPTION
The CRC must have 4 digits and if it has less it must be filled in with 0 in front.

Sources:
- https://www.bcb.gov.br/content/estabilidadefinanceira/spb_docs/ManualBRCode.pdf (page 10)
- https://developer.santander.com.br/sites/default/files/2021-06/Santander_QR_Code_Dinamico_0.pdf (slide 19)
- https://github.com/bacen/pix-api/issues/189#issuecomment-732316808